### PR TITLE
Add basic draw interactions

### DIFF
--- a/QWC2Components/actions/appmenu.js
+++ b/QWC2Components/actions/appmenu.js
@@ -7,6 +7,7 @@
  */
 
 const {changeMeasurement} = require('../../MapStore2/web/client/actions/measurement');
+const {changeDrawingStatus} = require('../../MapStore2/web/client/actions/draw');
 const {setCurrentTask} = require('./task');
 
 function triggerAppMenuitem(key) {
@@ -14,6 +15,11 @@ function triggerAppMenuitem(key) {
         return (dispatch => {
             dispatch(setCurrentTask('Measure'));
             dispatch(changeMeasurement({geomType: 'Point'}));
+        });
+    } else if(key === 'draw') {
+        return (dispatch => {
+            dispatch(setCurrentTask('Draw'));
+            dispatch(changeDrawingStatus('create'));
         });
     } else if(key === 'themes') {
         return setCurrentTask('ThemeSwitcher');

--- a/QWC2Components/actions/task.js
+++ b/QWC2Components/actions/task.js
@@ -8,11 +8,13 @@
 
 const SET_CURRENT_TASK = 'SET_CURRENT_TASK';
 const {changeMeasurement} = require('../../MapStore2/web/client/actions/measurement');
+const {changeDrawingStatus} = require('../../MapStore2/web/client/actions/draw');
 const {changeMapInfoState} = require('../../MapStore2/web/client/actions/mapInfo');
 
 function setCurrentTask(task) {
     return (dispatch) => {
         dispatch(changeMeasurement({geomType: null}));
+        dispatch(changeDrawingStatus(null));
         dispatch(changeMapInfoState(task === null));
         dispatch({
             type: SET_CURRENT_TASK,

--- a/QWC2Components/plugins/Draw.jsx
+++ b/QWC2Components/plugins/Draw.jsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016, Invit.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const {connect} = require('react-redux');
+const assign = require('object-assign');
+const MessageBar = require('../components/MessageBar');
+const {changeDrawingStatus, endDrawing} = require('../../MapStore2/web/client/actions/draw');
+const {setCurrentTask} = require('../actions/task');
+
+const Draw = React.createClass({
+  propTypes: {
+    drawStatus: React.PropTypes.string,
+    drawOwner: React.PropTypes.string,
+    drawMethod: React.PropTypes.string,
+    features: React.PropTypes.array,
+    changeDrawingStatus: React.PropTypes.func,
+    endDrawing: React.PropTypes.func,
+    setCurrentTask: React.PropTypes.func
+  },
+  getDefaultProps() {
+    return {
+      drawStatus: 'create',
+      drawMethod: null,
+      drawOwner: 'draw_dialog',
+      features: []
+    }
+  },
+  onClose() {
+    this.props.setCurrentTask(null);
+    this.props.changeDrawingStatus(null, null, null, []);
+  },
+  setDrawMethod(method) {
+    this.props.changeDrawingStatus('start', method, 'draw_dialog', []);
+  },
+  render() {
+    if(!this.props.drawStatus) {
+      return null;
+    }
+
+    return (
+      <div>
+        <MessageBar name="Draw" onClose={this.onClose}>
+            <span role="body">
+                <div className="buttonbar">
+                  <span onClick={()=>this.setDrawMethod('Point')} className={this.props.drawMethod == 'Point' ? 'active' : ''}> Point</span>
+                  <span onClick={()=>this.setDrawMethod('LineString')} className={this.props.drawMethod == 'LineString' ? 'active' : ''}> Line</span>
+                  <span onClick={()=>this.setDrawMethod('Polygon')} className={this.props.drawMethod == 'Polygon' ? 'active' : ''}> Polygon</span>
+                  <span onClick={()=>this.setDrawMethod('BBOX')} className={this.props.drawMethod == 'BBOX' ? 'active' : ''}> BBOX</span>
+                  <span onClick={()=>this.setDrawMethod('Circle')} className={this.props.drawMethod == 'Circle' ? 'active' : ''}> Circle</span>
+                </div>
+            </span>
+        </MessageBar>
+      </div>
+    );
+  }
+});
+
+const selector = (state) => ({
+  drawStatus: state.draw.drawStatus,
+  drawMethod: state.draw.drawMethod,
+  drawOwner: state.draw.drawOwner,
+  features: state.draw.features
+});
+
+module.exports = {
+ DrawPlugin: connect(selector, {
+   setCurrentTask: setCurrentTask,
+   changeDrawingStatus: changeDrawingStatus,
+   endDrawing: endDrawing
+ })(Draw),
+ reducers: {
+   draw: require('../../MapStore2/web/client/reducers/draw')
+ }
+}

--- a/QWC2Components/plugins/Map.jsx
+++ b/QWC2Components/plugins/Map.jsx
@@ -44,7 +44,8 @@ const QWCMapPlugin = React.createClass({
                 actions={{onMapViewChanges: changeMapView}}
                 zoomControl={this.props.zoomControl}
                 mapType={this.props.mapType}
-                options={options} />
+                options={options}
+                tools={['measurement', 'draw', 'locate', 'overview', 'scalebar']} />
         );
     }
 });


### PR DESCRIPTION
This PR includes basic interactions for drawing points, lines, polygons, bbox and circles. Since functionality of this plugin is highly dependant on current capabilities of MapStore, it's challenging to make this PR feature complete. It'd be good to avoid having long-lasting PRs, so this one could probably be merged and further functionality(like styling and editing drawings) developed in separate PRs.